### PR TITLE
fixes #107 -  Enable further customization of the CustomTypeProvider

### DIFF
--- a/src/Kentico.Kontent.ModelGenerator.Core/TypeProviderCodeGenerator.cs
+++ b/src/Kentico.Kontent.ModelGenerator.Core/TypeProviderCodeGenerator.cs
@@ -63,17 +63,17 @@ namespace {_namespace}
 {{
     public class {CLASS_NAME} : ITypeProvider
     {{
-        private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
+        protected static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
         {{
 {CreateCodenameDictionaryValues()}
         }};
 
-        public Type GetType(string contentType)
+        public virtual Type GetType(string contentType)
         {{
             return _codenames.Keys.FirstOrDefault(type => GetCodename(type).Equals(contentType));
         }}
 
-        public string GetCodename(Type contentType)
+        public virtual string GetCodename(Type contentType)
         {{
             return _codenames.TryGetValue(contentType, out var codename) ? codename : null;
         }}

--- a/test/Kentico.Kontent.ModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
+++ b/test/Kentico.Kontent.ModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
@@ -7,18 +7,18 @@ namespace KenticoKontentModels
 {
 	public class CustomTypeProvider : ITypeProvider
 	{
-		private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
+		protected static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
 		{
 			{typeof(Article), "article"},
 			{typeof(Office), "office"}
 		};
 
-		public Type GetType(string contentType)
+		public virtual Type GetType(string contentType)
 		{
 			return _codenames.Keys.FirstOrDefault(type => GetCodename(type).Equals(contentType));
 		}
 
-		public string GetCodename(Type contentType)
+		public virtual string GetCodename(Type contentType)
 		{
 			return _codenames.TryGetValue(contentType, out var codename) ? codename : null;
 		}


### PR DESCRIPTION
### Motivation
Enables further customization of the CustomTypeProvider

Fixes #107 


### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Check whether generated CustomTypeProvider contains:
1. _GetType_ and _GetCodename_ methods are marked as **virtual**
2. __codenames_ dictionary is marked as **protected**
3. valid C# code
 