### PR TITLE
Consume Delivery 19.4.0 (AngleSharp CVE + Refit signature fix) and stop persisting git credentials in CI

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
       contents: write   # Required for uploading release assets
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/src/Kontent.Ai.ModelGenerator.Core/Kontent.Ai.ModelGenerator.Core.csproj
+++ b/src/Kontent.Ai.ModelGenerator.Core/Kontent.Ai.ModelGenerator.Core.csproj
@@ -25,16 +25,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kontent.Ai.Delivery" Version="19.2.0" />
+    <PackageReference Include="Kontent.Ai.Delivery" Version="19.3.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <!-- Transitive via Kontent.Ai.Delivery, which still floors at 1.3.0. Pinned directly to
-         patch CVE-2026-54570; drop once the Delivery SDK raises its own floor to 1.5.0. -->
-    <PackageReference Include="AngleSharp" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kontent.Ai.Delivery.Abstractions" Version="19.2.0" />
+    <PackageReference Include="Kontent.Ai.Delivery.Abstractions" Version="19.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="../../kontent-ai-k-icon-color.png" Pack="true" PackagePath="" />

--- a/src/Kontent.Ai.ModelGenerator.Core/Kontent.Ai.ModelGenerator.Core.csproj
+++ b/src/Kontent.Ai.ModelGenerator.Core/Kontent.Ai.ModelGenerator.Core.csproj
@@ -25,13 +25,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kontent.Ai.Delivery" Version="19.3.1" />
+    <PackageReference Include="Kontent.Ai.Delivery" Version="19.4.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kontent.Ai.Delivery.Abstractions" Version="19.3.1" />
+    <PackageReference Include="Kontent.Ai.Delivery.Abstractions" Version="19.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="../../kontent-ai-k-icon-color.png" Pack="true" PackagePath="" />

--- a/src/Kontent.Ai.ModelGenerator.Core/Kontent.Ai.ModelGenerator.Core.csproj
+++ b/src/Kontent.Ai.ModelGenerator.Core/Kontent.Ai.ModelGenerator.Core.csproj
@@ -28,6 +28,9 @@
     <PackageReference Include="Kontent.Ai.Delivery" Version="19.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <!-- Transitive via Kontent.Ai.Delivery, which still floors at 1.3.0. Pinned directly to
+         patch CVE-2026-54570; drop once the Delivery SDK raises its own floor to 1.5.0. -->
+    <PackageReference Include="AngleSharp" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kontent.Ai.ModelGenerator/Kontent.Ai.ModelGenerator.csproj
+++ b/src/Kontent.Ai.ModelGenerator/Kontent.Ai.ModelGenerator.csproj
@@ -37,9 +37,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.15" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" />
 
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="../../kontent-ai-k-icon-color.png" Pack="true" PackagePath="" />

--- a/src/Kontent.Ai.ModelGenerator/Kontent.Ai.ModelGenerator.csproj
+++ b/src/Kontent.Ai.ModelGenerator/Kontent.Ai.ModelGenerator.csproj
@@ -37,9 +37,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
 
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="../../kontent-ai-k-icon-color.png" Pack="true" PackagePath="" />

--- a/test/Kontent.Ai.ModelGenerator.Core.Tests/Kontent.Ai.ModelGenerator.Core.Tests.csproj
+++ b/test/Kontent.Ai.ModelGenerator.Core.Tests/Kontent.Ai.ModelGenerator.Core.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kontent.Ai.Delivery.SourceGeneration" Version="19.2.0" />
+    <PackageReference Include="Kontent.Ai.Delivery.SourceGeneration" Version="19.4.0" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0,8.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
Clears all three open Aikido findings on `master`.

## AngleSharp CVE-2026-54570 (medium)

[CVE-2026-54570](https://github.com/advisories/GHSA-pgww-w46g-26qg) — mXSS via a MathML `annotation-xml` HTML integration point bypass, patched in AngleSharp 1.5.0.

AngleSharp is never referenced directly here; it arrives transitively through `Kontent.Ai.Delivery`, which floored at 1.3.0. This PR originally carried a direct `PackageReference` to 1.5.0 as a stopgap. That's now gone — [delivery-sdk-net#414](https://github.com/kontent-ai/delivery-sdk-net/pull/414) raised the SDK's own floor, so consuming Delivery fixes it at the source.

Verified: `dotnet list package --include-transitive` reports AngleSharp **1.5.0**, with no direct reference.

## Delivery 19.2.0 → 19.4.0

Originally 19.3.1; retargeted to **19.4.0** now that it has shipped. Two reasons beyond the CVE:

- **Refit 10.2.0.** The certificate that author-signed Refit 10.1.6 was revoked, so `dotnet restore` fails with `NU3012` on any pipeline with NuGet signature verification enabled ([reactiveui/refit#2114](https://github.com/reactiveui/refit/issues/2114)). 19.4.0 floors Refit at 10.2.0 — the same code re-signed with a valid certificate. Verified: Refit resolves to **10.2.0**, and this repo no longer needs the `DOTNET_NUGET_SIGNATURE_VERIFICATION` bypass.
- **A single `Microsoft.Extensions.*` servicing band.** 19.4.0 raises its own floors to 9.0.15, which left the CLI's direct pins at 9.0.3 — the same split this PR set out to remove. `Configuration.CommandLine`, `Configuration.Json` and `DependencyInjection` move 9.0.3 → **9.0.15** so the family stays on one band.

Also caught: `Kontent.Ai.Delivery.SourceGeneration` in the test project was still on **19.2.0** while the other references had moved. All Delivery references are now 19.4.0.

No `NU1605` downgrade errors, and no source changes — this is dependencies and CI only.

## Persisted git credentials in checkout (low ×2)

`persist-credentials: false` on the `actions/checkout` steps in `integrate.yml` and `release.yml`. Neither workflow pushes commits back — `release.yml` passes `GH_TOKEN` explicitly for `gh release upload`, so nothing depends on the persisted credential.

## Verification

`dotnet build` clean (0 warnings), 156 tests passing, AngleSharp 1.5.0 and Refit 10.2.0 both confirmed in the resolved graph.
